### PR TITLE
custom validations added, core profile path built

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name date_of_birth work_days_per_week work_hours_per_day sleep_hours_per_day])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[email password first_name last_name date_of_birth work_days_per_week work_hours_per_day sleep_hours_per_day])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name date_of_birth work_days_per_week work_hours_per_day sleep_hours_per_day])
+  end
 end

--- a/app/controllers/multistages_controller.rb
+++ b/app/controllers/multistages_controller.rb
@@ -1,5 +1,5 @@
 class MultistagesController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :configure_permitted_parameters, if: :devise_controller?
 
   def step1_input
   end
@@ -11,7 +11,7 @@ class MultistagesController < ApplicationController
       custom_params[:date_of_birth] = date_of_birth
     end
 
-    session[:user_data] ||= {}
+    session[:user_data] = {}
     session[:user_data][:step1] = custom_params
 
     @user = User.new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :home ]
+  before_action :authenticate_user!, except: [:home]
 
   def home
     @custom_column_class = "col-12" # Override default column class for the home page
@@ -9,4 +9,7 @@ class PagesController < ApplicationController
     redirect_to new_relationship
   end
 
+  def user_profile
+    @user = current_user
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :habits
   has_many :relationships
 
-  validates :first_name, :last_name, :date_of_birth, :work_days_per_week, :work_hours_per_day, :sleep_hours_per_day, presence: true
+  validates :first_name, :last_name, :email, :password, :date_of_birth, :work_days_per_week, :work_hours_per_day, :sleep_hours_per_day, presence: true
 
   validates :work_days_per_week, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 7, message: "must be less than or equal to 7" }
   validates :work_hours_per_day, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 24, message: "must be less than or equal to 24" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,11 +9,11 @@ class User < ApplicationRecord
   has_many :habits
   has_many :relationships
 
-  # validates :first_name, :last_name, :date_of_birth, :work_days_per_week, :work_hours_per_day, :sleep_hours_per_day, presence: true
+  validates :first_name, :last_name, :date_of_birth, :work_days_per_week, :work_hours_per_day, :sleep_hours_per_day, presence: true
 
-  # validates :work_days_per_week, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 7, message: "must be less than or equal to 7" }
-  # validates :work_hours_per_day, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 24, message: "must be less than or equal to 24" }
-  # validates :sleep_hours_per_day, numericality: { greater_than_or_equal_to: 0, message: "must be greater than 0" }
+  validates :work_days_per_week, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 7, message: "must be less than or equal to 7" }
+  validates :work_hours_per_day, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 24, message: "must be less than or equal to 24" }
+  validates :sleep_hours_per_day, numericality: { greater_than_or_equal_to: 0, message: "must be greater than 0" }
 
   # # MULTIFACTOR STEP VALIDATIONS
   validate :date_of_birth_validation, on: :step1_valid

--- a/app/views/devise/registrations/_active_since.html.erb
+++ b/app/views/devise/registrations/_active_since.html.erb
@@ -1,0 +1,14 @@
+<% account_created = user.created_at %>
+<% current_time = Time.zone.now %>
+
+<% minutes_active = (current_time - account_created) / 60 %>
+<% hours_active = minutes_active / 60 %>
+<% days_active = hours_active / 24 %>
+
+<% if minutes_active < 60 %>
+  <p><%= minutes_active.round(0) %> minute(s)</p>
+<% elsif hours_active < 24 %>
+  <p><%= hours_active.round(0) %> hour(s)</p>
+<% else %>
+  <p><%= days_active.round(0) %> day(s)</p>
+<% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,20 +9,20 @@
             <%= f.input :first_name,
                         required: true,
                         autofocus: true,
-                        input_html: { autocomplete: "first-name" }%>
+                        input_html: { autocomplete: "first-name" } %>
           </div>
           <div class="col-6">
             <%= f.input :last_name,
                         required: true,
                         autofocus: true,
-                        input_html: { autocomplete: "first-name" }%>
+                        input_html: { autocomplete: "first-name" } %>
           </div>
         </div>
       </div>
       <%= f.input :email,
                   required: true,
                   autofocus: true,
-                  input_html: { autocomplete: "email" }%>
+                  input_html: { autocomplete: "email" } %>
       <%= f.input :password,
                   required: true,
                   hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/app/views/pages/user_profile.html.erb
+++ b/app/views/pages/user_profile.html.erb
@@ -1,1 +1,13 @@
-<h2>Hi <%= @user.first_name %>!</h2>
+<h1>Hi, <%= @user.first_name %>!</h1>
+<h4>Member for:<%= render 'devise/registrations/active_since', user: @user %></h4>
+
+<h2>Account Details</h2>
+<p><strong>First Name:</strong> <%= @user.first_name %></p>
+<p><strong>Last Name:</strong> <%= @user.last_name %></p>
+<p><strong>Email:</strong> <%= @user.email %></p>
+<p><strong>DOB:</strong>  <%= @user.date_of_birth %></p>
+
+<h3>Unavoidables (Avg)</h3>
+<p><strong>Work Days:</strong> <%= @user.work_days_per_week %> per week</p>
+<p><strong>Work Hours:</strong> <%= @user.work_hours_per_day %> per day</p>
+<p><strong>Sleep Hours:</strong> <%= @user.sleep_hours_per_day %> per day</p>

--- a/app/views/pages/user_profile.html.erb
+++ b/app/views/pages/user_profile.html.erb
@@ -1,0 +1,1 @@
+<h2>Hi <%= @user.first_name %>!</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,6 @@ Rails.application.routes.draw do
       post 'add_session_data', as: :add_session_data
     end
   end
+
+  get "profile", to: "pages#user_profile", as: :profile
 end


### PR DESCRIPTION
ADDED

- custom validations to application_controller instead of authenticate_user! base
- basic profile page set up with the route "/profile" and method in the pages controller
- signup validations run for custom params and add them when creating a user

NEED NEXT

- ensure all pages are linked up to the new devise validation (**no longer skip_before_action :authenticate_user!**)
?
- work on relationship validation in tandem with user creation