### PR TITLE
Updated back-button labels 

### DIFF
--- a/app/views/multistages/step2_input.html.erb
+++ b/app/views/multistages/step2_input.html.erb
@@ -8,6 +8,6 @@
 
     <button type="button"
       class="secondary-btn"
-      data-action="click->multistage-step2#stepBack">Back to previous</button>
+      data-action="click->multistage-step2#stepBack">Back</button>
   </div>
 </div>

--- a/app/views/multistages/step3_input.html.erb
+++ b/app/views/multistages/step3_input.html.erb
@@ -20,5 +20,5 @@
 
   <button type="button"
     class="secondary-btn"
-    data-action="click->multistage-step3#stepBack">Back to previous</button>
+    data-action="click->multistage-step3#stepBack">Back</button>
 </div>


### PR DESCRIPTION
On the input screens, the buttons now say "back" instead of "back to previous"