### PR TITLE
Updated fill-speed of the life-in-year table

### DIFF
--- a/app/javascript/controllers/multistage_step2_output_controller.js
+++ b/app/javascript/controllers/multistage_step2_output_controller.js
@@ -244,7 +244,7 @@ export default class extends Controller {
   colorCircles(years, small = false) {
     const circles = this.tableTarget.querySelectorAll(`.${this.getCircleClass(small)}`);
     let delay = 0; // Initial delay in milliseconds
-    const delayIncrement = small ? 2 : 30; // Delay increment for each circle to create the animation effect
+    const delayIncrement = small ? 1 : 30; // Delay increment for each circle to create the animation effect
 
     circles.forEach(circle => {
       const circleYear = parseInt(circle.getAttribute('data-year'), 10);


### PR DESCRIPTION
Life-in-year output coloring in step 2 of the multi-stage signup is now 1ms per day vs 2ms per day previously