### PR TITLE
Updated tooltips in habit creation

### DIFF
--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -4,26 +4,28 @@ export default class extends Controller {
   static targets = ["tticon", "ttcard", "ttcross"]
 
   connect() {
-    console.log("Hello from the tooltip controller");
+    console.log('Hello from the tooltip controller');
   }
 
   open(event) {
-    console.log("Tooltip clicked to open");
-    this.ttcardTarget.classList.remove("d-none");
+    console.log('Tooltip clicked to open');
+    this.ttcardTarget.classList.add('display-message');
+    console.log(this.ttcardTarget);
+    // debugger
   }
 
   close(event) {
     const clickedElement = event.target;
     if (!clickedElement.closest('.tooltip-card')) {
-      this.ttcardTarget.classList.add("d-none")
+      this.ttcardTarget.classList.remove('display-message')
     }
-    console.log("Tooltip clicked to close")
+    console.log('Tooltip clicked to close')
   }
 
   cross(event) {
     if (event.Target = this.ttcrossTarget) {
-      console.log("cross clicked")
-      this.ttcardTarget.classList.add("d-none")
+      console.log('cross clicked')
+      this.ttcardTarget.classList.remove('display-message')
     }
   }
 }

--- a/app/views/habits/_form_child.html.erb
+++ b/app/views/habits/_form_child.html.erb
@@ -31,7 +31,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-10 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -69,7 +69,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -91,7 +91,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -121,7 +121,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -129,7 +129,7 @@
               <h3><i class="fa-solid fa-xmark mb-0 ms-1" role="button" data-tooltip-target="ttcross" data-action="click->tooltip#cross"></i></h3>
               </div>
               <p>If you give yourself a little treat after completing a habit repetition, you're more likely to stick with the habit.</p>
-              <p>Completed a 5k Park Run? Why not enjoy a cappucino on the way home?</p>
+              <p>Completed a 5k Park Run? Why not enjoy a cappuccino on the way home?</p>
               <p>Some habits generate the reward implicitly, like organising date night with your partner or taking your Grandma out for lunch. For these habits, you can leave this blank.</p>
             </div>
           </div>

--- a/app/views/habits/_form_parent.html.erb
+++ b/app/views/habits/_form_parent.html.erb
@@ -31,7 +31,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-10 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -69,7 +69,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -91,7 +91,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -121,7 +121,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -129,7 +129,7 @@
               <h3><i class="fa-solid fa-xmark mb-0 ms-1" role="button" data-tooltip-target="ttcross" data-action="click->tooltip#cross"></i></h3>
               </div>
               <p>If you give yourself a little treat after completing a habit repetition, you're more likely to stick with the habit.</p>
-              <p>Completed a 5k Park Run? Why not enjoy a cappucino on the way home?</p>
+              <p>Completed a 5k Park Run? Why not enjoy a cappuccino on the way home?</p>
               <p>Some habits generate the reward implicitly, like organising date night with your partner or taking your Grandma out for lunch. For these habits, you can leave this blank.</p>
             </div>
           </div>

--- a/app/views/habits/_form_partner.html.erb
+++ b/app/views/habits/_form_partner.html.erb
@@ -31,7 +31,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-10 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -69,7 +69,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -91,7 +91,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -121,7 +121,7 @@
         <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
           <i class="tooltip-icon fa-solid fa-circle-info"></i>
         </button>
-        <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+        <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
           <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
             <div class="tooltip-content">
               <div class="tooltip-headline d-flex justify-content-between">
@@ -129,7 +129,7 @@
               <h3><i class="fa-solid fa-xmark mb-0 ms-1" role="button" data-tooltip-target="ttcross" data-action="click->tooltip#cross"></i></h3>
               </div>
               <p>If you give yourself a little treat after completing a habit repetition, you're more likely to stick with the habit.</p>
-              <p>Completed a 5k Park Run? Why not enjoy a cappucino on the way home?</p>
+              <p>Completed a 5k Park Run? Why not enjoy a cappuccino on the way home?</p>
               <p>Some habits generate the reward implicitly, like organising date night with your partner or taking your Grandma out for lunch. For these habits, you can leave this blank.</p>
             </div>
           </div>

--- a/app/views/habits/edit.html.erb
+++ b/app/views/habits/edit.html.erb
@@ -44,7 +44,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-10 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -82,7 +82,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -104,7 +104,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -134,7 +134,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -142,7 +142,7 @@
                   <h3><i class="fa-solid fa-xmark mb-0 ms-1" role="button" data-tooltip-target="ttcross" data-action="click->tooltip#cross"></i></h3>
                   </div>
                   <p>If you give yourself a little treat after completing a habit repetition, you're more likely to stick with the habit.</p>
-                  <p>Completed a 5k Park Run? Why not enjoy a cappucino on the way home?</p>
+                  <p>Completed a 5k Park Run? Why not enjoy a cappuccino on the way home?</p>
                   <p>Some habits generate the reward implicitly, like organising date night with your partner or taking your Grandma out for lunch. For these habits, you can leave this blank.</p>
                 </div>
               </div>

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -44,7 +44,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-10 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -82,7 +82,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -104,7 +104,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -134,7 +134,7 @@
             <button type="button" data-action="click->tooltip#open" data-tooltip-target="tticon">
               <i class="tooltip-icon fa-solid fa-circle-info"></i>
             </button>
-            <div class="d-none tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
+            <div class="tooltip-back d-flex justify-content-center" data-tooltip-target="ttcard" data-action="click->tooltip#close">
               <div class="tooltip-card col-9 col-md-7 col-lg-6 col-xl-5 align-self-center p-3">
                 <div class="tooltip-content">
                   <div class="tooltip-headline d-flex justify-content-between">
@@ -142,7 +142,7 @@
                   <h3><i class="fa-solid fa-xmark mb-0 ms-1" role="button" data-tooltip-target="ttcross" data-action="click->tooltip#cross"></i></h3>
                   </div>
                   <p>If you give yourself a little treat after completing a habit repetition, you're more likely to stick with the habit.</p>
-                  <p>Completed a 5k Park Run? Why not enjoy a cappucino on the way home?</p>
+                  <p>Completed a 5k Park Run? Why not enjoy a cappuccino on the way home?</p>
                   <p>Some habits generate the reward implicitly, like organising date night with your partner or taking your Grandma out for lunch. For these habits, you can leave this blank.</p>
                 </div>
               </div>


### PR DESCRIPTION
 Fixes issue of not appearing on click. The tooltips show and hide is now based on the .display-message class in combination with the .tooltip-back class it sits with